### PR TITLE
fix: Fix localizing organization names

### DIFF
--- a/ckanext/harvester_dashboard/helpers.py
+++ b/ckanext/harvester_dashboard/helpers.py
@@ -1,37 +1,33 @@
-# encoding: utf-8
-
 import json
 import logging
 
-import ckan.plugins.toolkit as tk
 from ckan.lib.helpers import lang
+from ckan.lib.i18n import get_available_locales
 
 log = logging.getLogger(__name__)
 
 
 def get_localized_value_from_language_dict(value):
-    """display localized value of a language dict"""
-    user_language = lang()
-    try:
-        localized_value = value.get(user_language)
-        if localized_value:
-            return localized_value
-        locales = tk.config.get("ckan.locales_offered", None)
-        if locales:
-            for locale in locales.split(" "):
-                if value.get(locale):
-                    return value.get(locale)
-    except Exception:
-        return value
+    """Display localized value of a language dict."""
+    localized_value = value.get(lang())
+    if localized_value:
+        return localized_value
+
+    for locale in get_available_locales():
+        if value.get(locale.language):
+            return value.get(locale.language)
+
+    return value
 
 
 def harvester_dashboard_organization_title(value):
-    """display organization title and consider the cases that it is a value,
-    a language dict or a language dict warpped as json string"""
+    """Display organization title and consider the cases that it is a value, a language
+    dict, or a language dict dumped to a json string.
+    """
     if isinstance(value, dict):
         return get_localized_value_from_language_dict(value)
     try:
         value = json.loads(value)
         return get_localized_value_from_language_dict(value)
-    except ValueError:
+    except (AttributeError, ValueError):
         return value


### PR DESCRIPTION
- Get the locales to use with the appropriate helper function
- Handle available locales as a list, not a string
- Don't silently catch all possible exceptions